### PR TITLE
Export Playwright's cookies for inclusion in certain API calls

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -9,9 +9,11 @@ var url = process.argv[2];
 
         const verifyFp = await signer.getVerifyFp();
         const token = await signer.sign(url)
+        const cookies = await signer.getCookies();
         let output = JSON.stringify({
             signature: token,
             verifyFp: verifyFp,
+            cookies: cookies
           });
         console.log(output)
         await signer.close()

--- a/index.js
+++ b/index.js
@@ -106,6 +106,10 @@ class Signer {
     return null;
   }
 
+  async getCookies() {
+    return this.page.evaluate('document.cookie;');
+  }
+
   async close() {
     if (this.browser && !this.isExternalBrowser) {
       await this.browser.close();

--- a/listen.js
+++ b/listen.js
@@ -36,9 +36,11 @@ const http = require("http");
           try {
             const verifyFp = await signer.getVerifyFp();
             const token = await signer.sign(url);
+            const cookies = await signer.getCookies();
             let output = JSON.stringify({
               signature: token,
               verifyFp: verifyFp,
+              cookies: cookies
             });
             response.writeHead(200, { "Content-Type": "application/json" });
             response.end(output);


### PR DESCRIPTION
Simple change to include the browser's cookies in the signature JSON responses. Useful for some API calls as of a few days ago, it seems ( #79 ).