### PR TITLE
Add missing dependencies for the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,9 @@ RUN apt-get install -y libwoff1 \
     libgstreamer1.0-0 \
     libgstreamer-gl1.0-0 \
     libgstreamer-plugins-base1.0-0 \
-    libgstreamer-plugins-bad1.0-0
+    libgstreamer-plugins-bad1.0-0 \
+    libharfbuzz-icu0 \
+    libopenjp2-7
 
 # 3. Install Chromium dependencies
 


### PR DESCRIPTION
When trying to run the docker container this error pops up:
```
2020-08-09T11:27:29: PM2 log: Launching in no daemon mode
2020-08-09T11:27:29: PM2 log: App [listen:0] starting in -fork mode-
2020-08-09T11:27:29: PM2 log: App [listen:0] online
TikTok Signature server started
Error: browserType.launch: Host system is missing dependencies!
  Install missing packages with:
      apt-get install libharfbuzz-icu0\
          libopenjp2-7
Note: use DEBUG=pw:api environment variable and rerun to capture Playwright logs.
    at validateDependenciesLinux (/usr/node_modules/playwright-webkit/lib/server/validateDependencies.js:131:11)
    at async validateDependencies (/usr/node_modules/playwright-webkit/lib/server/validateDependencies.js:45:16)
    at async Object.validateHostRequirements (/usr/node_modules/playwright-webkit/lib/server/validateDependencies.js:34:5)
    at async WebKit._launchServer (/usr/node_modules/playwright-webkit/lib/server/browserType.js:154:13)
    at async WebKit._innerLaunch (/usr/node_modules/playwright-webkit/lib/server/browserType.js:76:61)
    at async ProgressController.run (/usr/node_modules/playwright-webkit/lib/progress.js:75:28)
    at async WebKit.launch (/usr/node_modules/playwright-webkit/lib/server/browserType.js:62:25)
    at async Signer.init (/usr/index.js:42:22)
```

And when trying to call the endpoint this:
```
Received url: https://m.tiktok.com/share/item/list?secUid=&id=&type=5&count=30&minCursor=0&maxCursor=0&shareUid=
TypeError: Cannot read property 'cookies' of undefined
    at Signer.getVerifyFp (/usr/index.js:100:38)
    at IncomingMessage.<anonymous> (/usr/listen.js:37:43)
    at IncomingMessage.emit (events.js:327:22)
    at endReadableNT (_stream_readable.js:1220:12)
    at processTicksAndRejections (internal/process/task_queues.js:84:21)
```

Adding the missing dependencies solves both.