### PR TITLE
feat: sign request body for POST endpoints (builds on #262)

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -559,6 +559,9 @@ async function ensurePageReady() {
  * Triggers fetch, SDK signs it, we capture and abort
  * @param {string} targetUrl - The URL to sign
  * @param {string|null} userAgent - Optional custom user agent to return in response
+ * @param {string|null} navigateTo - Optional TikTok page URL; selects the
+ *   page-intercept path. Mutually exclusive with body.
+ * @param {string} body - Optional request body the signature must cover.
  */
 async function generateSignedUrl(
   targetUrl,
@@ -577,6 +580,8 @@ async function generateSignedUrl(
  * @param {string|null} userAgent - Optional UA to return in response
  * @param {string|null} navigateTo - Optional TikTok page URL; when given,
  *   the response uses a page-intercept path instead of the default fast path.
+ * @param {string} body - Optional request body the signature must cover, for
+ *   POST endpoints. Mutually exclusive with navigateTo.
  */
 async function _generateSignedUrlInternal(
   targetUrl,
@@ -597,6 +602,17 @@ async function _generateSignedUrlInternal(
 
   const attempt = async () => {
     if (navigateTo) {
+      // The intercept path captures a signature TikTok's own page produced for
+      // its own request, so it can only ever cover that request's body. There
+      // is no way to make it cover a caller-supplied body — fail loudly rather
+      // than hand back a signature that silently doesn't match.
+      if (body) {
+        throw new Error(
+          "body is not supported together with navigateTo: the page-intercept " +
+            "path reuses a signature emitted by TikTok's page, which cannot " +
+            "cover a caller-supplied body. Omit navigateTo to sign a body.",
+        );
+      }
       console.log(`[Server] Sign via page intercept: navigateTo=${navigateTo}`);
       return _signViaPageIntercept(fetchUrl, navigateTo, userAgent);
     }
@@ -1083,6 +1099,21 @@ async function handleRequest(req, res) {
             status: "error",
             message:
               'URL is required in body as JSON { "url": "...", "navigateTo": "...", "userAgent": "..." } or plain text URL',
+          }),
+        );
+        return;
+      }
+
+      // The page-intercept path can't sign a caller-supplied body (see
+      // _generateSignedUrlInternal). Reject up front instead of spending a
+      // browser navigation on a request that can't be satisfied.
+      if (navigateTo && requestBody) {
+        res.writeHead(400);
+        res.end(
+          JSON.stringify({
+            status: "error",
+            message:
+              '"body" cannot be combined with "navigateTo" — the page-intercept path reuses a signature emitted by TikTok\'s page and cannot cover a caller-supplied body. Omit "navigateTo" to sign a body.',
           }),
         );
         return;

--- a/server.mjs
+++ b/server.mjs
@@ -6,7 +6,7 @@
  * Uses a persistent browser session with local SDK injection for reliable signature generation.
  *
  * Endpoints:
- * - POST /signature - Generate signed URL (body: { "url": "..." }) - RECOMMENDED for scalability
+ * - POST /signature - Generate signed URL (body: { "url": "...", "body": "<request body, for POST endpoints>" }) - RECOMMENDED for scalability
  * - POST /fetch     - Fetch through browser (slower, but 100% reliable fallback)
  * - GET  /health    - Health check
  * - GET  /restart   - Restart browser session
@@ -564,9 +564,10 @@ async function generateSignedUrl(
   targetUrl,
   userAgent = null,
   navigateTo = null,
+  body = "",
 ) {
   return queueSignatureRequest(() =>
-    _generateSignedUrlInternal(targetUrl, userAgent, navigateTo),
+    _generateSignedUrlInternal(targetUrl, userAgent, navigateTo, body),
   );
 }
 
@@ -581,6 +582,7 @@ async function _generateSignedUrlInternal(
   targetUrl,
   userAgent = null,
   navigateTo = null,
+  body = "",
 ) {
   await initBrowser();
   await ensurePageReady();
@@ -599,7 +601,7 @@ async function _generateSignedUrlInternal(
       return _signViaPageIntercept(fetchUrl, navigateTo, userAgent);
     }
     console.log(`[Server] Signing URL: ${fetchUrl.substring(0, 100)}...`);
-    return _signDirectly(fetchUrl, userAgent);
+    return _signDirectly(fetchUrl, userAgent, body);
   };
 
   try {
@@ -659,8 +661,9 @@ async function _signViaPageIntercept(targetUrl, navigateTo, userAgent = null) {
   );
 }
 
-async function _signDirectly(fetchUrl, userAgent = null) {
-  const out = await page.evaluate((url) => {
+async function _signDirectly(fetchUrl, userAgent = null, bodyStr = "") {
+  // prettier-ignore
+  const out = await page.evaluate((url, body) => {
     if (typeof window.__sdkN === "undefined") {
       return { error: "SDK not initialized" };
     }
@@ -722,7 +725,7 @@ async function _signDirectly(fetchUrl, userAgent = null) {
         ? window.byted_acrawler
         : null;
     try {
-      const xb = u995.call(acrawlerInst, queryString, "");
+      const xb = u995.call(acrawlerInst, queryString, body);
       return {
         urlBase: u.toString(),
         queryString,
@@ -735,16 +738,22 @@ async function _signDirectly(fetchUrl, userAgent = null) {
     } catch (e) {
       return { error: e.message, stack: e.stack };
     }
-  }, fetchUrl);
+  }, fetchUrl, bodyStr);
 
   if (out.error) {
     throw new Error("Sign failed: " + out.error);
   }
 
-  const xg = encodeXGnarly(out.queryString, "", out.userAgent, out.counters, {
-    ubcode: 4,
-    sdkVersion: "1.0.0.368",
-  });
+  const xg = encodeXGnarly(
+    out.queryString,
+    bodyStr,
+    out.userAgent,
+    out.counters,
+    {
+      ubcode: 4,
+      sdkVersion: "1.0.0.368",
+    },
+  );
 
   const u = new URL(out.urlBase);
   u.searchParams.set("X-Bogus", out.xBogus);
@@ -1045,6 +1054,7 @@ async function handleRequest(req, res) {
       let targetUrl = null;
       let userAgent = null;
       let navigateTo = null;
+      let requestBody = "";
 
       // Try to parse as JSON first
       try {
@@ -1052,6 +1062,12 @@ async function handleRequest(req, res) {
         if (json.url) targetUrl = json.url;
         if (json.userAgent) userAgent = json.userAgent;
         if (json.navigateTo) navigateTo = json.navigateTo;
+        // For POST endpoints: forward the body so the signature covers it.
+        if (json.body != null)
+          requestBody =
+            typeof json.body === "string"
+              ? json.body
+              : JSON.stringify(json.body);
       } catch (e) {
         // Body might be a direct URL string
         try {
@@ -1072,7 +1088,12 @@ async function handleRequest(req, res) {
         return;
       }
 
-      const result = await generateSignedUrl(targetUrl, userAgent, navigateTo);
+      const result = await generateSignedUrl(
+        targetUrl,
+        userAgent,
+        navigateTo,
+        requestBody,
+      );
 
       res.writeHead(200);
       res.end(


### PR DESCRIPTION
Builds on @roest01's work in #262, plus a follow-up fix for a gap in it.

## What #262 does

The signature was always computed with an empty body (`""`) as the second argument to the SDK signer and `encodeXGnarly`. That is correct for GET, but POST endpoints whose X-Bogus/X-Gnarly cover the request body were rejected, because the signature did not match the body. `/signature` now accepts an optional `body`, threaded through to both the SDK sign call and `encodeXGnarly`.

All credit for that commit goes to @roest01 — it is included here unmodified (`e4a0d84`).

## What this PR adds

`_signViaPageIntercept` was left untouched by #262. A caller passing both `body` and `navigateTo` got back a signature computed over an **empty** body, with no error and no warning — the worst failure mode, since the mismatch only surfaces later as an opaque rejection from TikTok.

That path cannot be fixed by threading the body through it. It captures a signature TikTok's own page emitted for its own request, so it can only ever cover *that* request's body. The combination is unsatisfiable, so it should fail loudly:

- `_generateSignedUrlInternal` throws when `body` is set on the `navigateTo` branch — covers every caller of `generateSignedUrl`, not just the HTTP route.
- `/signature` returns **400** up front, so a bad request does not spend a 60s browser navigation before failing.

Plus JSDoc on both functions recording that the two params are mutually exclusive.

## Verification

- `node --check` pass, `prettier --check` pass, `npm test` 5/5 pass
- Runtime: booted the server and hit `/signature` —
  - `{url, navigateTo, body}` -> 400 with the explanatory message
  - `{}` -> 400, original message unchanged (no regression)
  - server log confirms no `page.goto` fired, i.e. it rejects before navigating

## Not verified

The core claim of #262 — that POST bodies now produce signatures TikTok actually accepts — is **not** covered by CI. The test suite only asserts that files exist and the SDK contains certain strings; it does not exercise signing. Confirming it needs a live TikTok POST endpoint. Worth a manual check before merging.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
